### PR TITLE
Fixed check sheet when USB printing

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8410,7 +8410,7 @@ Sigma_Exit:
       M880
   */
     case 880:
-      steel_sheet_check();
+      steel_sheet_check(IS_SD_PRINTING);
     break;
 
 

--- a/Firmware/util.cpp
+++ b/Firmware/util.cpp
@@ -613,9 +613,9 @@ void ip4_to_str(char* dest, uint8_t* IP)
 }
 
 
-void steel_sheet_check()
+void steel_sheet_check(bool bCheckSD)
 { 
-    if (!is_usb_printing)
+    if (bCheckSD)
     {
         const int8_t sheetNR = eeprom_read_byte(&(EEPROM_Sheets_base->active_sheet));
         const int8_t nextSheet = eeprom_next_initialized_sheet(sheetNR);

--- a/Firmware/util.h
+++ b/Firmware/util.h
@@ -110,7 +110,7 @@ void gcode_level_check(uint16_t nGcodeLevel);
 
 void fSetMmuMode(bool bMMu);
 
-void steel_sheet_check();
+void steel_sheet_check(bool bCheckSD);
 
 #define IP4_STR_SIZE 16
 extern void ip4_to_str(char* dest, uint8_t* IP);


### PR DESCRIPTION
Arreglado un bug que pedía confirmación del usuario cuando estaba imprimiendo desde "USB" para que mirase si la plancha puesta era la que tenía el perfil.